### PR TITLE
deps: bump github.com/katbyte/sergi-go-diff to `v1.2.2`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/katbyte/andreyvit-diff
 
 go 1.19
 
-require github.com/katbyte/sergi-go-diff v1.2.1
+require github.com/katbyte/sergi-go-diff v1.2.2
 
 require github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/katbyte/sergi-go-diff v1.2.1 h1:etD07v2OL+HOzN32zF202yZbpzoUkizbfvbggpBSn/s=
-github.com/katbyte/sergi-go-diff v1.2.1/go.mod h1:BxkLLDDB1iVQsnURErqoQMjkyXIlR0DefDKzZCUHNEw=
+github.com/katbyte/sergi-go-diff v1.2.2 h1:QfvxByYpWiTcWXVDAxuAx+SY7vY2WEsboJKBDR54Egs=
+github.com/katbyte/sergi-go-diff v1.2.2/go.mod h1:BxkLLDDB1iVQsnURErqoQMjkyXIlR0DefDKzZCUHNEw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=


### PR DESCRIPTION
The upstream `terrafmt` tool depends on this library, which depends on `sergi-go-diff`. 

Due to an issue with published tags, `v1.2.1` was no longer present on GitHub, but still existed in the `golang.org` proxy. This presented issues when users tried to install tooling dependent on this library without going through the proxy (i.e. `GOPROXY=",direct"`).

```console
% GOPROXY='https://proxy.golang.org/,direct' go list -m --versions github.com/katbyte/sergi-go-diff
github.com/katbyte/sergi-go-diff v1.0.0 v1.1.0 v1.1.1 v1.2.1
% GOPROXY=",direct" go list -m --versions github.com/katbyte/sergi-go-diff
github.com/katbyte/sergi-go-diff v1.0.0 v1.1.0 v1.1.1
```

```console
% cd .ci/tools && go1.23.2 install github.com/katbyte/terrafmt
go: downloading github.com/katbyte/sergi-go-diff v1.2.1
../../../../go/pkg/mod/github.com/katbyte/andreyvit-diff@v0.0.1/diff.go:7:2: reading github.com/katbyte/sergi-go-diff/go.mod at revision v1.2.1: unknown revision v1.2.1
```

Updating to `v1.2.2` which will be present both on Github and the `golang.org` proxy should allow users to install the upstream tooling regardless of their personal `GOPROXY` configuration.